### PR TITLE
アカウントリストにローディングスケルトンを実装

### DIFF
--- a/src/app/dashboard/twitter-acount/_components/twitter-account-list/index.skeleton.tsx
+++ b/src/app/dashboard/twitter-acount/_components/twitter-account-list/index.skeleton.tsx
@@ -1,0 +1,44 @@
+import { Twitter } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+
+function AccountCardSkeleton() {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-center space-x-3">
+        <Skeleton className="h-12 w-12 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-[200px]" />
+          <Skeleton className="h-4 w-[150px]" />
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="h-8 w-8" />
+          <Skeleton className="h-8 w-8" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AccountListSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="border-b">
+        <div className="flex items-center">
+          <CardTitle className="flex items-center gap-4 text-2xl font-bold">
+            <Twitter className="h-6 w-6 text-blue-400" />
+            登録済みアカウント
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6">
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <AccountCardSkeleton key={i} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/src/app/dashboard/twitter-acount/page.tsx
+++ b/src/app/dashboard/twitter-acount/page.tsx
@@ -1,19 +1,22 @@
-import React from "react";
+import React, { Suspense } from "react";
 
 import { api, HydrateClient } from "~/trpc/server";
 import { TwitterAccountButton } from "./_components/twitter-account-button";
 import { TwitterAccountsListPage } from "./_components/twitter-account-list";
+import { AccountListSkeleton } from "./_components/twitter-account-list/index.skeleton";
 
 export default function TwitterAcountPage() {
-  void api.twitterAccount.all.prefetch();
+  void api.twitterAccount.all.prefetch(); // レンダリングプロセス中にプレフェッチされる
   return (
-    <div className="container mx-auto space-y-8 px-4">
-      <div className="flex justify-end">
-        <TwitterAccountButton />
+    <HydrateClient>
+      <div className="container mx-auto space-y-8 px-4">
+        <div className="flex justify-end">
+          <TwitterAccountButton />
+        </div>
+        <Suspense fallback={<AccountListSkeleton />}>
+          <TwitterAccountsListPage />
+        </Suspense>
       </div>
-      <HydrateClient>
-        <TwitterAccountsListPage />
-      </HydrateClient>
-    </div>
+    </HydrateClient>
   );
 }


### PR DESCRIPTION
- アカウントリストにローディングスケルトンを実装しました。
- 実装自体はできたのですが、```dashboard/twitter-account/page.tsx```の``` void api.twitterAccount.all.prefetch();```を消すとエラーがでる。ブラウザでエラーが出たあと、データ自体は取得はできているっぽい。```Switched to client rendering```とエラーメッセージにあるから、サーバーサイドでセッション情報の取得に失敗し、クライアントサイドでもう一度試したらセッション情報があったからデータが表示されたみたいな流れだと思うが、``` dashboard/twitter-account/_components/twitter-account-list/index.tsxには ``` ` use client` ```をつけているのに、なぜサーバーサイドで呼び出される?. tRPCはサーバーアクションとして実装されている?サーバーアクションとして実行したあと、エラーが出たらクライアントサイドで呼び出す?
- ここらへんの疑問を解決するのに時間はかかりそう。春休み中にゆっくり解決しよう